### PR TITLE
Add admin mode with teacher authentication

### DIFF
--- a/src/static/app.js
+++ b/src/static/app.js
@@ -3,6 +3,90 @@ document.addEventListener("DOMContentLoaded", () => {
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
+  const signupContainer = document.getElementById("signup-container");
+  const teacherOnlyNotice = document.getElementById("teacher-only-notice");
+
+  const userMenuBtn = document.getElementById("user-menu-btn");
+  const adminMenu = document.getElementById("admin-menu");
+  const authStatus = document.getElementById("auth-status");
+  const loginBtn = document.getElementById("login-btn");
+  const logoutBtn = document.getElementById("logout-btn");
+
+  const loginModal = document.getElementById("login-modal");
+  const closeLoginModal = document.getElementById("close-login-modal");
+  const loginForm = document.getElementById("login-form");
+  const loginMessage = document.getElementById("login-message");
+
+  let isAdmin = false;
+  let adminUsername = null;
+
+  function getToken() {
+    return localStorage.getItem("adminToken");
+  }
+
+  function setSession(token, username) {
+    localStorage.setItem("adminToken", token);
+    localStorage.setItem("adminUsername", username);
+    isAdmin = true;
+    adminUsername = username;
+    updateAuthUI();
+  }
+
+  function clearSession() {
+    localStorage.removeItem("adminToken");
+    localStorage.removeItem("adminUsername");
+    isAdmin = false;
+    adminUsername = null;
+    updateAuthUI();
+  }
+
+  async function authFetch(url, options = {}) {
+    const token = getToken();
+    const headers = new Headers(options.headers || {});
+    if (token) {
+      headers.set("Authorization", `Bearer ${token}`);
+    }
+
+    return fetch(url, {
+      ...options,
+      headers,
+    });
+  }
+
+  function updateAuthUI() {
+    if (isAdmin) {
+      authStatus.textContent = `Logged in as ${adminUsername}`;
+      loginBtn.classList.add("hidden");
+      logoutBtn.classList.remove("hidden");
+      signupContainer.classList.remove("hidden");
+      teacherOnlyNotice.classList.add("hidden");
+    } else {
+      authStatus.textContent = "Not logged in";
+      loginBtn.classList.remove("hidden");
+      logoutBtn.classList.add("hidden");
+      signupContainer.classList.add("hidden");
+      teacherOnlyNotice.classList.remove("hidden");
+    }
+  }
+
+  async function syncSessionFromServer() {
+    const token = getToken();
+    if (!token) {
+      clearSession();
+      return;
+    }
+
+    const response = await authFetch("/auth/status");
+    const result = await response.json();
+
+    if (result.authenticated) {
+      isAdmin = true;
+      adminUsername = result.username;
+      updateAuthUI();
+    } else {
+      clearSession();
+    }
+  }
 
   // Function to fetch activities from API
   async function fetchActivities() {
@@ -12,6 +96,8 @@ document.addEventListener("DOMContentLoaded", () => {
 
       // Clear loading message
       activitiesList.innerHTML = "";
+      activitySelect.innerHTML =
+        '<option value="">-- Select an activity --</option>';
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
@@ -30,7 +116,11 @@ document.addEventListener("DOMContentLoaded", () => {
                 ${details.participants
                   .map(
                     (email) =>
-                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
+                      `<li><span class="participant-email">${email}</span>${
+                        isAdmin
+                          ? `<button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button>`
+                          : ""
+                      }</li>`
                   )
                   .join("")}
               </ul>
@@ -57,9 +147,11 @@ document.addEventListener("DOMContentLoaded", () => {
       });
 
       // Add event listeners to delete buttons
-      document.querySelectorAll(".delete-btn").forEach((button) => {
-        button.addEventListener("click", handleUnregister);
-      });
+      if (isAdmin) {
+        document.querySelectorAll(".delete-btn").forEach((button) => {
+          button.addEventListener("click", handleUnregister);
+        });
+      }
     } catch (error) {
       activitiesList.innerHTML =
         "<p>Failed to load activities. Please try again later.</p>";
@@ -69,12 +161,16 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // Handle unregister functionality
   async function handleUnregister(event) {
+    if (!isAdmin) {
+      return;
+    }
+
     const button = event.target;
     const activity = button.getAttribute("data-activity");
     const email = button.getAttribute("data-email");
 
     try {
-      const response = await fetch(
+      const response = await authFetch(
         `/activities/${encodeURIComponent(
           activity
         )}/unregister?email=${encodeURIComponent(email)}`,
@@ -114,11 +210,18 @@ document.addEventListener("DOMContentLoaded", () => {
   signupForm.addEventListener("submit", async (event) => {
     event.preventDefault();
 
+    if (!isAdmin) {
+      messageDiv.textContent = "Teacher login required";
+      messageDiv.className = "error";
+      messageDiv.classList.remove("hidden");
+      return;
+    }
+
     const email = document.getElementById("email").value;
     const activity = document.getElementById("activity").value;
 
     try {
-      const response = await fetch(
+      const response = await authFetch(
         `/activities/${encodeURIComponent(
           activity
         )}/signup?email=${encodeURIComponent(email)}`,
@@ -155,6 +258,62 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   });
 
+  userMenuBtn.addEventListener("click", () => {
+    adminMenu.classList.toggle("hidden");
+  });
+
+  loginBtn.addEventListener("click", () => {
+    loginMessage.classList.add("hidden");
+    loginModal.classList.remove("hidden");
+    adminMenu.classList.add("hidden");
+  });
+
+  closeLoginModal.addEventListener("click", () => {
+    loginModal.classList.add("hidden");
+  });
+
+  logoutBtn.addEventListener("click", async () => {
+    await authFetch("/auth/logout", { method: "POST" });
+    clearSession();
+    fetchActivities();
+    adminMenu.classList.add("hidden");
+  });
+
+  loginForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    const username = document.getElementById("teacher-username").value;
+    const password = document.getElementById("teacher-password").value;
+
+    try {
+      const response = await fetch("/auth/login", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ username, password }),
+      });
+
+      const result = await response.json();
+      if (!response.ok) {
+        loginMessage.textContent = result.detail || "Login failed";
+        loginMessage.className = "error";
+        loginMessage.classList.remove("hidden");
+        return;
+      }
+
+      setSession(result.token, result.username);
+      loginForm.reset();
+      loginModal.classList.add("hidden");
+      fetchActivities();
+    } catch (error) {
+      loginMessage.textContent = "Login failed. Please try again.";
+      loginMessage.className = "error";
+      loginMessage.classList.remove("hidden");
+      console.error("Error during login:", error);
+    }
+  });
+
   // Initialize app
-  fetchActivities();
+  syncSessionFromServer().then(fetchActivities);
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -8,6 +8,16 @@
   </head>
   <body>
     <header>
+      <div class="header-top-row">
+        <div class="admin-controls">
+          <button id="user-menu-btn" class="user-icon-btn" title="Teacher access">👤</button>
+          <div id="admin-menu" class="admin-menu hidden">
+            <p id="auth-status">Not logged in</p>
+            <button id="login-btn" type="button">Login</button>
+            <button id="logout-btn" type="button" class="hidden">Logout</button>
+          </div>
+        </div>
+      </div>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
     </header>
@@ -21,7 +31,7 @@
         </div>
       </section>
 
-      <section id="signup-container">
+      <section id="signup-container" class="hidden">
         <h3>Sign Up for an Activity</h3>
         <form id="signup-form">
           <div class="form-group">
@@ -39,7 +49,31 @@
         </form>
         <div id="message" class="hidden"></div>
       </section>
+
+      <section id="teacher-only-notice">
+        <h3>Teacher Access Required</h3>
+        <p>Only logged-in teachers can register or unregister students.</p>
+      </section>
     </main>
+
+    <div id="login-modal" class="modal hidden">
+      <div class="modal-content">
+        <button id="close-login-modal" class="modal-close" type="button">✖</button>
+        <h3>Teacher Login</h3>
+        <form id="login-form">
+          <div class="form-group">
+            <label for="teacher-username">Username:</label>
+            <input type="text" id="teacher-username" required />
+          </div>
+          <div class="form-group">
+            <label for="teacher-password">Password:</label>
+            <input type="password" id="teacher-password" required />
+          </div>
+          <button type="submit">Login</button>
+        </form>
+        <div id="login-message" class="hidden"></div>
+      </div>
+    </div>
 
     <footer>
       <p>&copy; 2023 Mergington High School</p>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -22,6 +22,59 @@ header {
   background-color: #1a237e;
   color: white;
   border-radius: 5px;
+  position: relative;
+}
+
+.header-top-row {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 6px;
+  padding: 0 15px;
+}
+
+.admin-controls {
+  position: relative;
+}
+
+.user-icon-btn {
+  background-color: transparent;
+  border: 1px solid #ffffff88;
+  border-radius: 50%;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  font-size: 18px;
+}
+
+.user-icon-btn:hover {
+  background-color: #3949ab;
+}
+
+.admin-menu {
+  position: absolute;
+  right: 0;
+  top: 42px;
+  background: white;
+  color: #333;
+  border-radius: 8px;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.2);
+  min-width: 180px;
+  z-index: 20;
+  padding: 10px;
+}
+
+.admin-menu p {
+  margin-bottom: 10px;
+  font-size: 14px;
+}
+
+.admin-menu button {
+  width: 100%;
+  margin-bottom: 8px;
+}
+
+.admin-menu button:last-child {
+  margin-bottom: 0;
 }
 
 header h1 {
@@ -190,6 +243,38 @@ button:hover {
 
 .hidden {
   display: none;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 30;
+}
+
+.modal-content {
+  background: white;
+  border-radius: 8px;
+  width: min(420px, 90vw);
+  padding: 20px;
+  position: relative;
+}
+
+.modal-close {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background: transparent;
+  color: #333;
+  font-size: 18px;
+  padding: 4px 8px;
+}
+
+#teacher-only-notice p {
+  margin-top: 10px;
 }
 
 footer {

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,8 @@
+{
+  "teachers": [
+    {
+      "username": "teacher1",
+      "password": "mergington123"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Implements admin mode by restricting activity registration changes to authenticated teachers.

## Changes
- Added teacher authentication endpoints:
  - `POST /auth/login`
  - `POST /auth/logout`
  - `GET /auth/status`
- Added teacher credentials source in `src/teachers.json`
- Protected endpoints so only logged-in teachers can:
  - sign up students (`POST /activities/{activity_name}/signup`)
  - unregister students (`DELETE /activities/{activity_name}/unregister`)
- Added frontend teacher access UX:
  - user icon in top-right
  - login menu and modal
  - teacher-only registration controls
- Kept participant visibility for non-authenticated users.

## Notes
- Default teacher credential for testing:
  - username: `teacher1`
  - password: `mergington123`

Closes #5